### PR TITLE
cucumber的相關套件

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ Use git to clone this project into a folder. Then in this folder, run the comman
 
 * Start Web Application. Run com.odde.bbuddy.Application as a Spring Boot application by using "dev" as the active profile
 * Run Unit Tests. Run those unit tests as normal. The only limitation is that you can't run those "Nested" tests together with other non "Nested" tests
-* Run Acceptance Tests (cucumber). In feature file, you can select the feature or one scenario and then run it. In the configuration, you need to set the active profile as "test" by adding `SPRING_PROFILES_ACTIVE=test` to the environment variables. 安裝Cucumber for java pluging之後, 在Run/Debug Configurations裡面才會有Cucumber java可以設置, 然後才會執行Feature檔. 
+* Run Acceptance Tests (cucumber). In feature file, you can select the feature or one scenario and then run it. In the configuration, you need to set the active profile as "test" by adding `SPRING_PROFILES_ACTIVE=test` to the environment variables. 
+  * 安裝Cucumber for java pluging之後, 在Run/Debug Configurations裡面才會有Cucumber java可以設置, 然後才會執行Feature檔. 
 * [Spring Boot Developer Tools](http://docs.spring.io/spring-boot/docs/current/reference/html/using-boot-devtools.html) is used so that you can hot load any modified code, template file and resource file without restart the application. Please follow the steps below to enable this hot load feature.
     * Start the application in Intellij as described in the first item. Don't start it with gradle in command line.
     * Edit any code or file, and make the project. Then, the change will be reloaded automatically.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Please install the following tools for this project. The latest version should b
 * mysql
 * intellij idea community edition with the following plug-in installed
     * lombok plug-in
+    * Cucumber for java(為了執行cucumber feature)
+    * Gherkin(為了editor支援)
 * Firefox 46.0 (don't use higher version)
 
 # Setup Command Line Development Environment
@@ -27,7 +29,7 @@ Use git to clone this project into a folder. Then in this folder, run the comman
 
 * Start Web Application. Run com.odde.bbuddy.Application as a Spring Boot application by using "dev" as the active profile
 * Run Unit Tests. Run those unit tests as normal. The only limitation is that you can't run those "Nested" tests together with other non "Nested" tests
-* Run Acceptance Tests (cucumber). In feature file, you can select the feature or one scenario and then run it. In the configuration, you need to set the active profile as "test" by adding `SPRING_PROFILES_ACTIVE=test` to the environment variables.
+* Run Acceptance Tests (cucumber). In feature file, you can select the feature or one scenario and then run it. In the configuration, you need to set the active profile as "test" by adding `SPRING_PROFILES_ACTIVE=test` to the environment variables. 安裝Cucumber for java pluging之後，在Run/Debug Configurations裡面才會有Cucumber java可以設置
 * [Spring Boot Developer Tools](http://docs.spring.io/spring-boot/docs/current/reference/html/using-boot-devtools.html) is used so that you can hot load any modified code, template file and resource file without restart the application. Please follow the steps below to enable this hot load feature.
     * Start the application in Intellij as described in the first item. Don't start it with gradle in command line.
     * Edit any code or file, and make the project. Then, the change will be reloaded automatically.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Use git to clone this project into a folder. Then in this folder, run the comman
 
 * Start Web Application. Run com.odde.bbuddy.Application as a Spring Boot application by using "dev" as the active profile
 * Run Unit Tests. Run those unit tests as normal. The only limitation is that you can't run those "Nested" tests together with other non "Nested" tests
-* Run Acceptance Tests (cucumber). In feature file, you can select the feature or one scenario and then run it. In the configuration, you need to set the active profile as "test" by adding `SPRING_PROFILES_ACTIVE=test` to the environment variables. 安裝Cucumber for java pluging之後，在Run/Debug Configurations裡面才會有Cucumber java可以設置
+* Run Acceptance Tests (cucumber). In feature file, you can select the feature or one scenario and then run it. In the configuration, you need to set the active profile as "test" by adding `SPRING_PROFILES_ACTIVE=test` to the environment variables. 安裝Cucumber for java pluging之後, 在Run/Debug Configurations裡面才會有Cucumber java可以設置, 然後才會執行Feature檔. 
 * [Spring Boot Developer Tools](http://docs.spring.io/spring-boot/docs/current/reference/html/using-boot-devtools.html) is used so that you can hot load any modified code, template file and resource file without restart the application. Please follow the steps below to enable this hot load feature.
     * Start the application in Intellij as described in the first item. Don't start it with gradle in command line.
     * Edit any code or file, and make the project. Then, the change will be reloaded automatically.

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ Please install the following tools for this project. The latest version should b
 * mysql
 * intellij idea community edition with the following plug-in installed
     * lombok plug-in
-    * Cucumber for java(為了執行cucumber feature)
-    * Gherkin(為了editor支援)
+    * Cucumber for java
+    * Gherkin
 * Firefox 46.0 (don't use higher version)
 
 # Setup Command Line Development Environment


### PR DESCRIPTION
cucumber的feature檔需要plugin:Cucumber for java
否則社群版的IDE會直接用JUnit的configuration去執行單元測試
